### PR TITLE
Updating Annotations

### DIFF
--- a/recogito-annotation-editor/public/index.html
+++ b/recogito-annotation-editor/public/index.html
@@ -31,25 +31,26 @@
   <body>
     <div>
       <button id="add-annotation">Add Annotation</button>
+      <button id="update-annotation">Update Annotation</button>
       <button id="remove-annotation">Remove Annotation</button>
     </div>
 
     <div id="content" class="plaintext">
       <h1>Homer: The Odyssey</h1>
       <p>
-        <strong>Tell me, O muse,</strong> of that ingenious hero who travelled far and wide after he had sacked 
+        <strong>Tell me, O muse,</strong> of that ingenious hero who travelled far and wide after he had sacked
         the famous town of Troy. Many cities did he visit, and many were the nations with whose manners and customs
-        he was acquainted; moreover he suffered much by sea while trying to save his own life and bring his men safely 
-        home; but do what he might he could not save his men, for they perished through their own sheer folly in eating 
+        he was acquainted; moreover he suffered much by sea while trying to save his own life and bring his men safely
+        home; but do what he might he could not save his men, for they perished through their own sheer folly in eating
         the cattle of the Sun-god Hyperion; so the god prevented them from ever reaching home. Tell me, too, about all
         these things, O daughter of Jove, from whatsoever source you may know them.
       </p>
       <p>
-        <strong>So now all who escaped death in battle</strong> or by shipwreck had got safely home except Ulysses, 
-        and he, though he was longing to return to his wife and country, was detained by the goddess Calypso, who 
-        had got him into a large cave and wanted to marry him. But as years went by, there came a time when the gods 
-        settled that he should go back to Ithaca; even then, however, when he was among his own people, his troubles 
-        were not yet over; nevertheless all the gods had now begun to pity him except Neptune, who still persecuted 
+        <strong>So now all who escaped death in battle</strong> or by shipwreck had got safely home except Ulysses,
+        and he, though he was longing to return to his wife and country, was detained by the goddess Calypso, who
+        had got him into a large cave and wanted to marry him. But as years went by, there came a time when the gods
+        settled that he should go back to Ithaca; even then, however, when he was among his own people, his troubles
+        were not yet over; nevertheless all the gods had now begun to pity him except Neptune, who still persecuted
         him without ceasing and would not let him get home.
       </p>
     </div>
@@ -58,9 +59,10 @@
       // An example annotation we'll add/remove via JavaScript
       var myAnnotation = {
         '@context': 'http://www.w3.org/ns/anno.jsonld',
+        'id': 'https://www.example.com/recogito-js-example/foo',
         'type': 'Annotation',
         'body': [{
-          'type': 'TextualBody', 
+          'type': 'TextualBody',
           'value': 'This annotation was added via JS.'
         }],
         'target': {
@@ -68,8 +70,8 @@
             'type': 'TextQuoteSelector',
             'exact': 'that ingenious hero'
           }, {
-            'type': 'TextPositionSelector', 
-            'start': 38, 
+            'type': 'TextPositionSelector',
+            'start': 38,
             'end': 57
           }]
         }
@@ -78,11 +80,11 @@
       (function() {
         // Intialize Recogito
         var r = Recogito.init({
-          content: 'content' // Element id or DOM node to attach to 
+          content: 'content' // Element id or DOM node to attach to
         });
 
         r.loadAnnotations('annotations.w3c.json');
-    
+
         r.on('createAnnotation', function(a) {
           console.log('created', a);
         });
@@ -96,6 +98,25 @@
           r.addAnnotation(myAnnotation);
         });
 
+        document.getElementById('update-annotation').addEventListener('click', function() {
+          r.addAnnotation({
+            ...myAnnotation,
+            'body': [{
+              'type': 'TextualBody',
+              'value': 'This annotation was added via JS, and has been updated now.'
+            }],
+            'target': {
+              'selector': [{
+                'type': 'TextQuoteSelector',
+                'exact': 'ingenious hero who'
+              }, {
+                'type': 'TextPositionSelector',
+                'start': 43,
+                'end': 61
+              }]
+            }
+          });
+        });
         document.getElementById('remove-annotation').addEventListener('click', function() {
           r.removeAnnotation(myAnnotation);
         });

--- a/recogito-text-highlights/src/annotation/WebAnnotation.js
+++ b/recogito-text-highlights/src/annotation/WebAnnotation.js
@@ -9,9 +9,16 @@ export default class WebAnnotation {
     return new WebAnnotation(Object.assign({}, this._annotation));
   }
 
-  /** An equality check based on the underlying object **/
+  /** An equality check based on the underlying object or (if given) ID **/
   isEqual(other) {
-    return other ? this._annotation === other._annotation : false;
+    if (!other) {
+      return false;
+    } else if (this._annotation === other._annotation) {
+      return true;
+    } else if (!this._annotation.id || !other._annotation.id) {
+      return false;
+    }
+    return this._annotation.id === other._annotation.id
   }
 
   /*************************************/ 

--- a/recogito-text-highlights/test/web-annotation.js
+++ b/recogito-text-highlights/test/web-annotation.js
@@ -1,0 +1,68 @@
+import assert from "assert";
+import WebAnnotation from "../src/annotation/WebAnnotation";
+
+const fixtureAnnotation = {
+  "@context": "http://www.w3.org/ns/anno.jsonld",
+  id: "https://www.example.com/recogito-js-example/foo",
+  type: "Annotation",
+  body: [
+    {
+      type: "TextualBody",
+      value: "This annotation was added via JS."
+    }
+  ],
+  target: {
+    selector: [
+      {
+        type: "TextQuoteSelector",
+        exact: "that ingenious hero"
+      },
+      {
+        type: "TextPositionSelector",
+        start: 38,
+        end: 57
+      }
+    ]
+  }
+};
+
+describe("WebAnnotation", function() {
+  describe("#isEqual()", function() {
+    it("should return true if the other is the same object", () => {
+      const a = new WebAnnotation(fixtureAnnotation);
+      const b = new WebAnnotation(fixtureAnnotation);
+      assert(a.isEqual(b));
+    });
+    it("should return false if either annotation has no ID set", () => {
+      const a = new WebAnnotation({
+        ...fixtureAnnotation,
+        id: "https://www.example.com/anno1"
+      });
+      const b = new WebAnnotation({ ...fixtureAnnotation });
+      assert.strictEqual(a.isEqual(b), false);
+      assert.strictEqual(b.isEqual(a), false);
+    });
+    it("should return true iff annotation IDs do match", () => {
+      const a = new WebAnnotation({
+        ...fixtureAnnotation,
+        id: "https://www.example.com/anno1"
+      });
+      const b = new WebAnnotation({
+        ...fixtureAnnotation,
+        id: "https://www.example.com/anno2"
+      });
+      const c = new WebAnnotation({
+        ...fixtureAnnotation,
+        id: "https://www.example.com/anno1",
+        body: [
+          {
+            type: "TextualBody",
+            value: "foobar"
+          }
+        ]
+      });
+      assert.strictEqual(a.isEqual(b), false);
+      assert.strictEqual(a.isEqual(c), true);
+    });
+  });
+});


### PR DESCRIPTION
Closes #17. Check annotation equality by their ID, add tests. Add a naive approach for _‘replacing’_ annotations by removing the old highlightings and adding new ones.

What do you think of this approach, @rsimon? I'd guess it would be more elegant to reuse the existing highlight spans, but I didn't find an intuitive way of calculating which spans would be superfluous and which ones would be reused when considering complex multi-line highlightings.

Also, I'd say we need to move the editor window if an annotation range changed, but that could be added in a future PR.